### PR TITLE
Set webhook listeners for alert group signals

### DIFF
--- a/engine/apps/webhooks/apps.py
+++ b/engine/apps/webhooks/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class WebhooksConfig(AppConfig):
+    name = "apps.webhooks"
+
+    def ready(self):
+        from . import signals  # noqa: F401

--- a/engine/apps/webhooks/listeners.py
+++ b/engine/apps/webhooks/listeners.py
@@ -1,0 +1,24 @@
+import logging
+
+from django.apps import apps
+
+from .tasks import alert_group_created, alert_group_status_change
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+def on_alert_created(**kwargs):
+    Alert = apps.get_model("alerts", "Alert")
+    alert_pk = kwargs["alert"]
+    alert = Alert.objects.get(pk=alert_pk)
+
+    alert_group_created.apply_async((alert.group_id,))
+
+
+def on_action_triggered(**kwargs):
+    AlertGroupLogRecord = apps.get_model("alerts", "AlertGroupLogRecord")
+    log_record = kwargs["log_record"]
+    if not isinstance(log_record, AlertGroupLogRecord):
+        log_record = AlertGroupLogRecord.objects.get(pk=log_record)
+    alert_group_status_change.apply_async((log_record.type, log_record.alert_group_id, log_record.author_id))

--- a/engine/apps/webhooks/signals.py
+++ b/engine/apps/webhooks/signals.py
@@ -1,0 +1,10 @@
+from apps.alerts.signals import (
+    alert_create_signal,
+    alert_group_action_triggered_signal,
+)
+
+from .listeners import on_action_triggered, on_alert_created
+
+
+alert_create_signal.connect(on_alert_created)
+alert_group_action_triggered_signal.connect(on_action_triggered)

--- a/engine/apps/webhooks/tasks.py
+++ b/engine/apps/webhooks/tasks.py
@@ -1,0 +1,26 @@
+import logging
+
+from common.custom_celery_tasks import shared_dedicated_queue_retry_task
+
+from celery.utils.log import get_task_logger
+from django.conf import settings
+
+logger = get_task_logger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+MAX_RETRIES = 10
+
+
+@shared_dedicated_queue_retry_task(
+    bind=True, autoretry_for=(Exception,), retry_backoff=True, max_retries=1 if settings.DEBUG else MAX_RETRIES
+)
+def alert_group_created(self, alert_group_id):
+    logger.error("CREATED AG ID: %s", alert_group_id)
+
+
+@shared_dedicated_queue_retry_task(
+    bind=True, autoretry_for=(Exception,), retry_backoff=True, max_retries=1 if settings.DEBUG else MAX_RETRIES
+)
+def alert_group_status_change(self, action_type, alert_group_id, user_id):
+    logger.error("TYPE: %s AG ID: %s USER ID: %s", action_type, alert_group_id, user_id)


### PR DESCRIPTION
I was first triggering a task in all the different places the event is triggered, but we already have the signal in those places (and also for bulk actions), so decided to plug into the signals for now. Also this allows to work on webhooks without any changes to the existing code.